### PR TITLE
Fix BoxAreaFilter range check

### DIFF
--- a/pycocoedit/objectdetection/filter.py
+++ b/pycocoedit/objectdetection/filter.py
@@ -222,10 +222,10 @@ class BoxAreaFilter(BaseFilter):
 
     @override
     def apply(self, data: dict) -> bool:
-        if self.min_area and self.max_area:
+        if self.min_area is not None and self.max_area is not None:
             return self.min_area <= data["area"] <= self.max_area
-        elif self.min_area:
+        elif self.min_area is not None:
             return self.min_area <= data["area"]
-        elif self.max_area:
+        elif self.max_area is not None:
             return data["area"] <= self.max_area
         return True

--- a/tests/pycocoedit/objectdetection/test_filter.py
+++ b/tests/pycocoedit/objectdetection/test_filter.py
@@ -122,6 +122,9 @@ def test_category_exclude_filter(category_names, data, expected):
         (100, None, {"area": 99}, False),
         (100, None, {"area": 100}, True),
         (100, None, {"area": 101}, True),
+        (0, 10, {"area": 0}, True),
+        (0, 10, {"area": 11}, False),
+        (0, None, {"area": 5}, True),
     ],
 )
 def test_box_area_include_filter(min_area, max_area, data, expected):


### PR DESCRIPTION
## Summary
- handle 0 values correctly in `BoxAreaFilter.apply`
- expand filter test coverage for zero areas

## Testing
- `pytest -q` *(fails: command not found)*